### PR TITLE
Use pyyaml's safe_load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/arwn/cmd/collect.py
+++ b/arwn/cmd/collect.py
@@ -64,7 +64,7 @@ def event_loop(config):
 
 def main():
     args = parse_args()
-    config = yaml.load(open(args.config, 'r').read())
+    config = yaml.safe_load(open(args.config, 'r').read())
     if not args.foreground:
         fh, logger = setup_logger(config.get('logfile', args.logfile))
         try:

--- a/arwn/engine.py
+++ b/arwn/engine.py
@@ -228,7 +228,7 @@ class RFXCOMCollector(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         try:
             event = self.transport.receive_blocking()
             self.unparsable = 0
@@ -262,7 +262,7 @@ class RTL433Collector(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         line = self.rtl.stdout.readline()
         data = json.loads(line)
         self.log_data(data)


### PR DESCRIPTION
Removes the warning on build. Also uses python3's iterable definition of `__next__`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/arwn/3)
<!-- Reviewable:end -->
